### PR TITLE
Add ident and convert to accept hostnames too

### DIFF
--- a/exe/dpident.cc
+++ b/exe/dpident.cc
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////////
+//
+// Stuart B. Wilkins <swilkins@bnl.gov>
+//
+// Created on : 10/03/2020 10:03:21 AM
+//
+////////////////////////////////////////////////////////////////////
+
+
+#include <iostream>
+#include <unistd.h>
+
+#include "PMAC2Turbo.h"
+
+
+int dpident (std::string const& IP)
+{
+
+  PMAC2Turbo PMAC(IP, 1025);
+
+  PMAC.SendLine("IDNUMBER");
+  sleep(5);
+  PMAC.GetBuffer();
+
+  return 0;
+}
+
+
+int main (int argc, char* argv[])
+{
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " [IP]" << std::endl;
+    return 1;
+  }
+
+  dpident(argv[1]);
+
+  return 0;
+}


### PR DESCRIPTION
This does 2 changes:
- Allow host lookups so that hostnames can be passed 
- Adds an Ident routine (thanks @johnsinsheimer !) for re-ip 

See:

```
❯ ./bin/dpident 10.66.10.104
2000001724CFE101
❯ nslookup xf02idb-mc02.nsls2.bnl.local
Server:		127.0.0.53
Address:	127.0.0.53#53

Non-authoritative answer:
Name:	xf02idb-mc02.nsls2.bnl.local
Address: 10.66.10.104

❯ ./bin/dpident xf02idb-mc02.nsls2.bnl.local
2000001724CFE101
```
